### PR TITLE
set cypher-linter to build from source to get latest fixes

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: cypher-linter
   name: Neo4J Cypher linter
   description: Neo4J Cypher linting via docker_image
-  entry: cybergrx/cypher-linter:1.0.0
+  entry: cybergrx/cypher-linter:1.0.1
   language: docker_image
   files: \.(cypher|cql|cpy)$
 - id: graphql-linter

--- a/cypher-linter/Dockerfile
+++ b/cypher-linter/Dockerfile
@@ -15,9 +15,15 @@ ARG VERSION
 
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-    add-apt-repository ppa:cleishm/neo4j && \
-    apt-get update && \
-    apt-get install -y cypher-lint && \
+    apt-get install -y git peg autoconf automake libtool apt-utils && \
+    git clone https://github.com/cleishm/libcypher-parser.git && \
+    cd libcypher-parser && \
+    ./autogen.sh && \
+    ./configure && \
+    make clean check && \
+    make install && \
+    cd .. && \
+    ldconfig && \
     echo "${VERSION}" > cypher-linter.version
 
 ENTRYPOINT ["cypher-lint", "--colorize"]


### PR DESCRIPTION
updated dockerfile for cypher-lint to build from latest master commits. this will pull in fixes for linting apoc functions. fixes #1 